### PR TITLE
Fix important bugs from code review

### DIFF
--- a/cmd/deputy/deputy.go
+++ b/cmd/deputy/deputy.go
@@ -50,7 +50,7 @@ func runJob(job *model.Job) {
 			delete(tr.Task.Args, "_assets")
 
 			if err := encoder.Encode(tr); err != nil {
-				panic(err)
+				log.Fatal("gob encode:", err)
 			}
 
 			// terminate play for this host if any task failed
@@ -84,7 +84,7 @@ func runJob(job *model.Job) {
 			}
 			delete(tr.Task.Args, "_assets")
 			if err := encoder.Encode(tr); err != nil {
-				panic(err)
+				log.Fatal("gob encode:", err)
 			}
 			if tr.Status == runners.Failed {
 				return

--- a/cmd/deputy/deputy.go
+++ b/cmd/deputy/deputy.go
@@ -32,13 +32,13 @@ func runJob(job *model.Job) {
 			var tr model.TaskResult
 			if task.Unless != "" {
 				if _, err := exec.Command("/bin/sh", "-c", task.Unless).CombinedOutput(); err == nil {
-					tr.Status = runners.Success
+					tr.Status = model.StatusSuccess
 					tr.Output = fmt.Sprintf("skipped, 'unless' clause succeeded (%v)", task.Unless)
 				}
 			}
 
 			// if no "unless" or "unless" cmd failed, run the task
-			if tr.Status == runners.Unknown {
+			if tr.Status == model.StatusUnknown {
 				tr = runners.Run(&task, play.Vars)
 			}
 
@@ -54,7 +54,7 @@ func runJob(job *model.Job) {
 			}
 
 			// terminate play for this host if any task failed
-			if tr.Status == runners.Failed {
+			if tr.Status == model.StatusFailed {
 				return
 			}
 
@@ -71,7 +71,7 @@ func runJob(job *model.Job) {
 		}
 		for _, handler := range play.Handlers {
 			// empty tr in case of unnotified handler
-			tr := model.TaskResult{Status: runners.Skipped}
+			tr := model.TaskResult{Status: model.StatusSkipped}
 
 			if handlers[handler.Name] {
 				// log.Debug("Running handler", handler)
@@ -86,7 +86,7 @@ func runJob(job *model.Job) {
 			if err := encoder.Encode(tr); err != nil {
 				log.Fatal("gob encode:", err)
 			}
-			if tr.Status == runners.Failed {
+			if tr.Status == model.StatusFailed {
 				return
 			}
 		}

--- a/cmd/deputy/deputy_test.go
+++ b/cmd/deputy/deputy_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"testing"
 
+	"github.com/gwillem/whip/internal/model"
 	"github.com/gwillem/whip/internal/playbook"
 	"github.com/gwillem/whip/internal/runners"
 	"github.com/gwillem/whip/internal/testutil"
@@ -18,7 +19,7 @@ func Test_DeputyIntegration(t *testing.T) {
 	for _, play := range *pb {
 		for _, task := range play.Tasks {
 			res := runners.Run(&task, nil)
-			require.Equal(t, runners.Failed, res.Status)
+			require.Equal(t, model.StatusFailed, res.Status)
 		}
 	}
 }

--- a/cmd/whip/progressbar.go
+++ b/cmd/whip/progressbar.go
@@ -10,7 +10,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	log "github.com/gwillem/go-simplelog"
 	"github.com/gwillem/whip/internal/model"
-	"github.com/gwillem/whip/internal/runners"
 )
 
 const (
@@ -85,7 +84,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		b.total = msg.TaskTotal
 		b.idx = msg.TaskIdx
 
-		if tr.Status == runners.Failed {
+		if tr.Status == model.StatusFailed {
 			b.status = ERROR
 		} else if perc >= 1 {
 			b.status = DONE

--- a/cmd/whip/reporting.go
+++ b/cmd/whip/reporting.go
@@ -9,7 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	log "github.com/gwillem/go-simplelog"
 	"github.com/gwillem/whip/internal/model"
-	"github.com/gwillem/whip/internal/runners"
 )
 
 type (
@@ -40,13 +39,13 @@ func (h verboseHandler) Send(m model.ReportMsg) {
 	tr := m.TaskResult
 
 	switch {
-	case tr.Changed && tr.Status == runners.Success:
+	case tr.Changed && tr.Status == model.StatusSuccess:
 		statusColor = yellow
 		status = "changed"
-	case tr.Status == runners.Failed:
+	case tr.Status == model.StatusFailed:
 		statusColor = red
 		status = "error"
-	case tr.Status == runners.Skipped:
+	case tr.Status == model.StatusSkipped:
 		statusColor = dark
 		status = "skipped"
 
@@ -94,11 +93,11 @@ func reportResults(results <-chan model.TaskResult, stats map[model.TargetName]m
 		stats[res.Host]["idx"]++
 
 		switch {
-		case res.Changed && res.Status == runners.Success:
+		case res.Changed && res.Status == model.StatusSuccess:
 			stats[res.Host]["changed"]++
-		case res.Status == runners.Failed:
+		case res.Status == model.StatusFailed:
 			stats[res.Host]["error"]++
-		case res.Status == runners.Skipped:
+		case res.Status == model.StatusSkipped:
 			stats[res.Host]["skipped"]++
 		default:
 			stats[res.Host]["ok"]++
@@ -109,7 +108,7 @@ func reportResults(results <-chan model.TaskResult, stats map[model.TargetName]m
 			TaskTotal:  stats[res.Host]["total"],
 			TaskResult: res,
 		})
-		if res.Status == runners.Failed {
+		if res.Status == model.StatusFailed {
 			failed = append(failed, res)
 		}
 	}

--- a/cmd/whip/whip.go
+++ b/cmd/whip/whip.go
@@ -179,7 +179,7 @@ func runPreRunTasks(pb *model.Playbook) {
 
 		for _, task := range play.Tasks {
 			tr := runners.PreRun(&task, play.Vars)
-			if tr.Status == runners.Skipped {
+			if tr.Status == model.StatusSkipped {
 				continue
 			}
 			log.Debug("Pre-run", task.Runner, "with status", tr.Status, tr.Output)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/gwillem/whip
 go 1.24.0
 
 require (
-	dario.cat/mergo v1.0.1
 	filippo.io/age v1.2.1
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/charmbracelet/bubbles v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
 c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
-dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
-dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
 filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,6 +11,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const (
+	StatusUnknown int = iota
+	StatusSuccess
+	StatusFailed
+	StatusSkipped
+)
+
 func init() {
 	gob.Register(Asset{})
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -112,7 +112,10 @@ func (tr TaskResult) String() string {
 
 func (ta TaskArgs) String(s string) string {
 	if arg := ta[s]; arg != nil {
-		return arg.(string)
+		if str, ok := arg.(string); ok {
+			return str
+		}
+		return fmt.Sprintf("%v", arg)
 	}
 	return ""
 }

--- a/internal/runners/runners_run.go
+++ b/internal/runners/runners_run.go
@@ -104,6 +104,12 @@ func PreRun(task *model.Task, playVars model.TaskVars) (tr model.TaskResult) {
 	}
 
 	// merge play vars with task vars (play vars take precedence)
+	if playVars == nil {
+		playVars = model.TaskVars{}
+	}
+	if task.Vars == nil {
+		task.Vars = model.TaskVars{}
+	}
 	mergedVars, err := deepmerge.Merge(map[string]any(playVars), map[string]any(task.Vars))
 	if err != nil {
 		tr.Status = Failed
@@ -151,6 +157,12 @@ func Run(task *model.Task, playVars model.TaskVars) (tr model.TaskResult) {
 	}
 
 	// merge play vars with task vars (task vars take precedence)
+	if playVars == nil {
+		playVars = model.TaskVars{}
+	}
+	if task.Vars == nil {
+		task.Vars = model.TaskVars{}
+	}
 	merged, err := deepmerge.Merge(map[string]any(task.Vars), map[string]any(playVars))
 	if err != nil {
 		return fail(err.Error())

--- a/internal/runners/runners_run.go
+++ b/internal/runners/runners_run.go
@@ -15,11 +15,12 @@ import (
 	"github.com/spf13/afero"
 )
 
+// Status constants — canonical definitions live in model package.
 const (
-	Unknown int = iota
-	Success
-	Failed
-	Skipped
+	Unknown = model.StatusUnknown
+	Success = model.StatusSuccess
+	Failed  = model.StatusFailed
+	Skipped = model.StatusSkipped
 )
 
 type (

--- a/internal/runners/runners_run.go
+++ b/internal/runners/runners_run.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"dario.cat/mergo"
 	log "github.com/gwillem/go-simplelog"
 	"github.com/gwillem/whip/internal/model"
 	"github.com/ieee0824/go-deepmerge"
@@ -103,8 +102,7 @@ func PreRun(task *model.Task, playVars model.TaskVars) (tr model.TaskResult) {
 		return tr
 	}
 
-	// todo: isolate this
-	// merge global and task vars
+	// merge play vars with task vars (play vars take precedence)
 	mergedVars, err := deepmerge.Merge(map[string]any(playVars), map[string]any(task.Vars))
 	if err != nil {
 		tr.Status = Failed
@@ -112,8 +110,6 @@ func PreRun(task *model.Task, playVars model.TaskVars) (tr model.TaskResult) {
 		return
 	}
 	task.Vars = mergedVars.(map[string]any)
-
-	// todo: merge vars
 	tr = runner.prerun(task)
 	tr.Task = task
 	return tr
@@ -153,9 +149,12 @@ func Run(task *model.Task, playVars model.TaskVars) (tr model.TaskResult) {
 		}
 	}
 
-	if e := mergo.Merge(&task.Vars, playVars); e != nil {
-		return fail(e.Error())
+	// merge play vars with task vars (task vars take precedence)
+	merged, err := deepmerge.Merge(map[string]any(task.Vars), map[string]any(playVars))
+	if err != nil {
+		return fail(err.Error())
 	}
+	task.Vars = merged.(map[string]any)
 
 	// arg substitution, notably for loop {{item}}
 	for k, v := range task.Args {

--- a/internal/runners/runners_run_test.go
+++ b/internal/runners/runners_run_test.go
@@ -9,11 +9,36 @@ import (
 
 func init() {
 	registerRunner("dummy", runner{
+		run: func(t *model.Task) model.TaskResult {
+			return model.TaskResult{Status: Success}
+		},
 		prerun: func(t *model.Task) model.TaskResult {
 			// fmt.Println("inside dummy runner")
 			return model.TaskResult{Status: Skipped}
 		},
 	})
+}
+
+func Test_RunWithNilPlayVars(t *testing.T) {
+	task := model.Task{
+		Runner: "dummy",
+		Args:   model.TaskArgs{"_args": "hello"},
+		Vars:   model.TaskVars{"key": "val"},
+	}
+	tr := Run(&task, nil)
+	require.Equal(t, Success, tr.Status)
+	require.Equal(t, "val", task.Vars["key"])
+}
+
+func Test_RunWithNilTaskVars(t *testing.T) {
+	task := model.Task{
+		Runner: "dummy",
+		Args:   model.TaskArgs{"_args": "hello"},
+	}
+	playVars := model.TaskVars{"key": "from_play"}
+	tr := Run(&task, playVars)
+	require.Equal(t, Success, tr.Status)
+	require.Equal(t, "from_play", task.Vars["key"])
 }
 
 func Test_PreRun(t *testing.T) {

--- a/internal/runners/tree.go
+++ b/internal/runners/tree.go
@@ -371,12 +371,12 @@ func ensureFile(f filesObj) (changed bool, err error) {
 			return false, fmt.Errorf("write error to temp file %s for %s: %w", tempPath, f.path, err)
 		}
 
-		if tempFile.Close() != nil {
-			return false, fmt.Errorf("error closing temp file for %s: %w", f.path, err)
+		if e := tempFile.Close(); e != nil {
+			return false, fmt.Errorf("error closing temp file for %s: %w", f.path, e)
 		}
 
-		if fs.Chmod(tempPath, f.mode) != nil {
-			return false, fmt.Errorf("chmod error on temp file %s for %s: %w", tempPath, f.path, err)
+		if e := fs.Chmod(tempPath, f.mode); e != nil {
+			return false, fmt.Errorf("chmod error on temp file %s for %s: %w", tempPath, f.path, e)
 		}
 
 		// Perform the atomic rename

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -38,11 +38,15 @@ var defaultKeyFile = os.ExpandEnv("$HOME/.ssh/id_rsa")
 
 type (
 	Client struct {
-		cl *ssh.Client
+		cl        *ssh.Client
+		agentConn net.Conn
 	}
 )
 
 func (c *Client) Close() error {
+	if c.agentConn != nil {
+		c.agentConn.Close()
+	}
 	return c.cl.Close()
 }
 
@@ -132,6 +136,7 @@ func (c *Client) UploadBytes(data []byte, remote string, perm os.FileMode) error
 	if err != nil {
 		return err
 	}
+	defer remoteFile.Close()
 
 	_, err = remoteFile.Write(data)
 	if err != nil {
@@ -170,6 +175,7 @@ func (c *Client) UploadFile(local, remote string) error {
 	if err != nil {
 		return err
 	}
+	defer remoteFile.Close()
 
 	_, err = io.Copy(remoteFile, localFile)
 	if err != nil {
@@ -200,16 +206,16 @@ func Connect(target string) (*Client, error) {
 	authMethods := []ssh.AuthMethod{}
 
 	var err error
+	var agentConn net.Conn
 
 	// Try agent?
 	if os.Getenv(agentSock) != "" {
-		var agentConn net.Conn
 		if agentConn, err = net.Dial("unix", os.Getenv(agentSock)); err == nil {
-			// fmt.Println("Adding agent auth")
 			authMethod := ssh.PublicKeysCallback(agent.NewClient(agentConn).Signers)
 			authMethods = append(authMethods, authMethod)
 		} else {
 			log.Debug("Failed to connect to SSH agent:", agentSock, err)
+			agentConn = nil
 		}
 	}
 
@@ -244,7 +250,13 @@ func Connect(target string) (*Client, error) {
 	}
 	addr := fmt.Sprintf("%s:%s", host, port)
 	cl, err := ssh.Dial(tcp, addr, config)
-	return &Client{cl: cl}, err
+	if err != nil {
+		if agentConn != nil {
+			agentConn.Close()
+		}
+		return nil, err
+	}
+	return &Client{cl: cl, agentConn: agentConn}, nil
 }
 
 func splitTarget(target string) (user, host, port string) {

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -90,10 +90,10 @@ func RunGobStreamer[T any](c *Client, cmd string, stdin io.Reader, callback func
 		var obj T
 		err := dec.Decode(&obj)
 		if err == io.EOF {
-			// End of the stream
 			break
 		} else if err != nil {
-			log.Fatalf("error decoding GOB data: %v", err)
+			_ = s.Close()
+			return fmt.Errorf("error decoding GOB data: %w", err)
 		}
 		callback(obj)
 	}

--- a/internal/vault/convert.go
+++ b/internal/vault/convert.go
@@ -40,15 +40,21 @@ func ConvertAnsibleToWhip(root string) error {
 			return fmt.Errorf("oops reading %s: %w", path, err)
 		}
 
-		w, err := fs.Create(path)
+		tmpPath := path + ".tmp"
+		w, err := fs.Create(tmpPath)
 		if err != nil {
 			return err
 		}
-		defer w.Close()
 		if err := age.Encrypt(bytes.NewReader(source), w); err != nil {
+			w.Close()
+			fs.Remove(tmpPath)
 			return err
 		}
-		return nil
+		if err := w.Close(); err != nil {
+			fs.Remove(tmpPath)
+			return err
+		}
+		return fs.Rename(tmpPath, path)
 	})
 	if err != nil {
 		return err

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 )
@@ -162,19 +163,29 @@ func LaunchEditor(path string) error {
 		return e
 	}
 
-	// encrypt to orig path
+	// encrypt to a temp file, then atomically rename to original path
 	in, err := os.Open(tmp.Name())
 	if err != nil {
 		return err
 	}
 	defer in.Close()
 
-	out, err := os.Create(path)
+	outTmp, err := os.CreateTemp(filepath.Dir(path), ".whip-vault-*.tmp")
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	return readyVaulters()[0].Encrypt(in, out) // take first valid
+	outTmpPath := outTmp.Name()
+
+	if err := readyVaulters()[0].Encrypt(in, outTmp); err != nil {
+		outTmp.Close()
+		os.Remove(outTmpPath)
+		return err
+	}
+	if err := outTmp.Close(); err != nil {
+		os.Remove(outTmpPath)
+		return err
+	}
+	return os.Rename(outTmpPath, path)
 }
 
 func getEditor() string {


### PR DESCRIPTION
## Summary

- **Fix stale error wrapping** in tree.go temp file operations — `%w` was wrapping the wrong `err` variable from a prior operation instead of the actual Close/Chmod error
- **Fix SFTP resource leaks** — add `defer remoteFile.Close()` in UploadBytes/UploadFile, store and close SSH agent connection in Client
- **Fix fatal in library code** — RunGobStreamer now returns errors instead of calling log.Fatalf
- **Fix unsafe type assertion** in TaskArgs.String() — use comma-ok pattern to prevent panic on non-string values
- **Fix panic in deputy** — replace `panic(err)` with `log.Fatal` for clean error output on gob encode failures
- **Fix data loss risk in vault** — LaunchEditor and ConvertAnsibleToWhip now use atomic temp file + rename instead of overwriting originals before encryption completes
- **Standardize var merging** on deepmerge, drop mergo dependency; guard against nil maps
- **Move status constants** to model package where they semantically belong alongside TaskResult

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for nil playVars and nil task.Vars in Run()
- [x] Manual integration test with `whip` against a target host