### PR TITLE
fix: run without a tty (fall back to plain output)

### DIFF
--- a/cmd/whip/reporting.go
+++ b/cmd/whip/reporting.go
@@ -10,7 +10,20 @@ import (
 	log "github.com/gwillem/go-simplelog"
 	"github.com/gwillem/whip/internal/model"
 	"github.com/gwillem/whip/internal/runners"
+	"golang.org/x/term"
 )
+
+// useTUI reports whether the interactive bubbletea progress bar should be used.
+// The TUI needs a controlling terminal; without one (CI, cron, piped output)
+// bubbletea fails to open /dev/tty, so we fall back to the plain verbose handler.
+func useTUI(verbosity int, isTTY bool) bool {
+	return verbosity == 0 && isTTY
+}
+
+// isInteractive reports whether stdout is attached to a terminal.
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
 
 type (
 	resultHandler interface {
@@ -81,7 +94,7 @@ func trimDotDot(s string, lim int) string {
 
 func reportResults(results <-chan model.TaskResult, stats map[model.TargetName]map[string]int, verbosity int) {
 	var handler resultHandler = verboseHandler{}
-	if verbosity == 0 {
+	if useTUI(verbosity, isInteractive()) {
 		handler = tuiHandler{createTui()}
 	}
 

--- a/cmd/whip/reporting_test.go
+++ b/cmd/whip/reporting_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestUseTUI(t *testing.T) {
+	cases := []struct {
+		name      string
+		verbosity int
+		isTTY     bool
+		want      bool
+	}{
+		{"tty, no verbose -> tui", 0, true, true},
+		{"no tty, no verbose -> fallback", 0, false, false},
+		{"tty, verbose -> plain", 1, true, false},
+		{"no tty, verbose -> plain", 1, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := useTUI(c.verbosity, c.isTTY); got != c.want {
+				t.Errorf("useTUI(%d, %v) = %v, want %v", c.verbosity, c.isTTY, got, c.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.46.0
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9
+	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 


### PR DESCRIPTION
## Problem

Whip could not run in non-interactive contexts (CI, cron, piped output). `reportResults` selected the bubbletea TUI purely on `verbosity == 0`, with no terminal detection. Without a controlling tty, `tui.Run()` fails with `could not open a new TTY: open /dev/tty: device not configured`, and `createTui` turns that into `log.Fatal` — killing whip before any work runs.

## Fix

Detect whether stdout is a terminal via `golang.org/x/term.IsTerminal` and fall back to the existing plain-text `verboseHandler` when it is not. The TUI is still used when a real tty is present.

- `useTUI(verbosity, isTTY)` — TUI only when `verbosity == 0 && isTTY`
- `isInteractive()` — wraps `term.IsTerminal(os.Stdout.Fd())`
- Promotes `golang.org/x/term` to a direct dependency (was already transitive via bubbletea)

## Testing

- New unit test `TestUseTUI` covering the tty/verbosity matrix
- Full suite green (`go test ./...`)
- End-to-end: running a playbook with stdin/stdout redirected previously fataled with `could not open a new TTY`; it now proceeds to the actual task path
- `gofumpt`, `go fix`, `golangci-lint run` clean